### PR TITLE
Add portal deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ All assets referenced by `index.php` reside in this folder:
 - `assets/vodafone-logo.png` *(add your own logo image)*
 
 The credentials will be stored in `creds.txt` inside the same directory.
+
+## Deployment
+
+- Copy all files to the Pineapple's portal directory.
+- Ensure `evilportal-Vodafone.ep` uses Unix (LF) line endings.
+- Make `.enable` executable and leave `.disable` empty.
+
+Use the Pineapple web UI or run `portal enable evilportal-Vodafone` from the CLI to activate the portal.


### PR DESCRIPTION
## Summary
- document how to deploy the portal on the Pineapple
- mention enabling via the Pineapple UI or CLI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68448d64d4a88325a12480a541014f4c